### PR TITLE
[BB-451] baton-trayai: remove custom user type

### DIFF
--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -1,23 +1,12 @@
 package client
 
-// TrayType is the Tray.ai's type.
-type TrayType int
-
-const (
-	Embeded TrayType = iota + 1
-	Organiaztion
-	Personal
-	PersonalExternal
-	Shared
-)
-
 // User is the Tray.ai user.
 type User struct {
-	ID               string   `json:"id"`
-	Name             string   `json:"name"`
-	Type             TrayType `json:"type"`
-	Description      string   `json:"description"`
-	MonthlyTaskLimit int64    `json:"monthlyTaskLimit"`
+	ID               string `json:"id"`
+	Name             string `json:"name"`
+	Type             string `json:"type"`
+	Description      string `json:"description"`
+	MonthlyTaskLimit int64  `json:"monthlyTaskLimit"`
 }
 
 type PageInfo struct {


### PR DESCRIPTION
#### Description

Tray.ai returns `type` as string, so we don't need custom user type. 
<img width="1283" alt="image" src="https://github.com/user-attachments/assets/cd65ac2f-3177-447d-953c-4dba2d6efb0d" />

- [ ] Bug fix
- [ ] New feature




#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
