### PR TITLE
[BB-451] baton-trayai: fix roles grants issue

### DIFF
--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -221,7 +221,7 @@ func (c *Client) ListWorkspaceUsers(ctx context.Context, params ListParams) (*Li
 	return resp, nil
 }
 
-func (c *Client) GetUser(ctx context.Context, userID string) (*User, error) {
+func (c *Client) GetOrganizationUser(ctx context.Context, userID string) (*User, error) {
 	urlpath, err := url.Parse(basePath + fmt.Sprintf(getUserPath, userID))
 	if err != nil {
 		return nil, err
@@ -234,6 +234,34 @@ func (c *Client) GetUser(ctx context.Context, userID string) (*User, error) {
 		uhttp.WithContentTypeJSONHeader(),
 	)
 
+	if err != nil {
+		return nil, err
+	}
+
+	var resp *User
+	rawResp, err := c.httpClient.Do(req, uhttp.WithJSONResponse(&resp))
+	if err != nil {
+		return nil, err
+	}
+
+	defer rawResp.Body.Close()
+	return resp, nil
+}
+
+// GetWorkspaceUser is different from GetOrganizationUser since one user could have different roles in
+// different workspaces.
+func (c *Client) GetWorkspaceUser(ctx context.Context, userID string, workspaceID string) (*User, error) {
+	urlpath, err := url.Parse(basePath + fmt.Sprintf(getWorkspaceUserPath, workspaceID, userID))
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := c.httpClient.NewRequest(ctx,
+		http.MethodGet,
+		urlpath,
+		uhttp.WithAcceptJSONHeader(),
+		uhttp.WithContentTypeJSONHeader(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/client/models.go
+++ b/pkg/connector/client/models.go
@@ -17,6 +17,7 @@ type PageInfo struct {
 }
 
 type User struct {
+	WorkspaceID string `json:"workspaceId"`
 	ID          string `json:"id"`
 	Email       string `json:"email"`
 	Name        string `json:"name"`

--- a/pkg/connector/client/path.go
+++ b/pkg/connector/client/path.go
@@ -8,6 +8,7 @@ const (
 	listWorkspaceRolesPath = "/core/v1/workspaces/%s/roles"
 	listWorkspaceUsersPath = "/core/v1/workspaces/%s/users"
 
-	getUserPath      = "/core/v1/users/%s"
-	getWorkspacePath = "/core/v1/workspaces/%s"
+	getUserPath          = "/core/v1/users/%s"
+	getWorkspacePath     = "/core/v1/workspaces/%s"
+	getWorkspaceUserPath = "/core/v1/workspaces/%s/users/%s"
 )

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -18,12 +18,11 @@ type Connector struct {
 
 // ResourceSyncers returns a ResourceSyncer for each resource type that should be synced from the upstream service.
 func (d *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncer {
-	uBuilder := newUserBuilder(d.client)
-
+	wBuilder := newWorkspaceBuild(d.client)
 	return []connectorbuilder.ResourceSyncer{
-		uBuilder,
-		newWorkspaceBuild(d.client, uBuilder),
-		newRoleBuilder(d.client),
+		newUserBuilder(d.client),
+		wBuilder,
+		newRoleBuilder(d.client, wBuilder),
 	}
 }
 

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -31,7 +31,8 @@ func roleResource(e client.Element, parentResourceID *v2.ResourceId) (*v2.Resour
 
 // roleBuilder is the builder for workspace role.
 type roleBuilder struct {
-	client *client.Client
+	client   *client.Client
+	wbuilder *workspaceBuilder
 }
 
 func (r *roleBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -103,28 +104,29 @@ func (r *roleBuilder) Grants(ctx context.Context, v2Resource *v2.Resource, pToke
 		return nil, "", nil, nil
 	}
 
-	users, err := r.client.ListWorkspaceUsers(ctx, client.ListParams{
-		Cursor:      pToken.Token,
-		First:       pToken.Size,
-		WorkspaceID: v2Resource.ParentResourceId.Resource,
-	})
+	workspaceUsers, err := r.wbuilder.getWorkspaceUsers(ctx, v2Resource.ParentResourceId.Resource)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("baton-trayai: ListWorkspaceUsers failed: %w", err)
+		return nil, "", nil, err
 	}
 
-	rv := make([]*v2.Grant, 0, len(users.Elements))
-	for _, user := range users.Elements {
+	rv := make([]*v2.Grant, 0, len(workspaceUsers))
+	for _, user := range workspaceUsers {
+		if v2Resource.Id.Resource != user.Role.ID {
+			continue
+		}
+
 		userID, err := resource.NewResourceID(userResourceType, user.ID)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("baton-trayai: failed to create resourceID for user: %w", err)
 		}
 		rv = append(rv, grant.NewGrant(v2Resource, RoleAssignmentEntitlement, userID))
 	}
-	return rv, users.Page.EndCursor, nil, nil
+	return rv, "", nil, nil
 }
 
-func newRoleBuilder(c *client.Client) *roleBuilder {
+func newRoleBuilder(c *client.Client, wb *workspaceBuilder) *roleBuilder {
 	return &roleBuilder{
-		client: c,
+		client:   c,
+		wbuilder: wb,
 	}
 }

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -3,7 +3,6 @@ package connector
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -41,8 +40,6 @@ func userResource(
 
 type userBuilder struct {
 	client *client.Client
-	mu     sync.Mutex
-	users  map[string]*client.User // map[userID]*User
 }
 
 func (o *userBuilder) ResourceType(ctx context.Context) *v2.ResourceType {
@@ -64,11 +61,8 @@ func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 		return nil, "", nil, fmt.Errorf("baton-trayai: ListUsers failed: %w", err)
 	}
 
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
 	for _, element := range resp.Elements {
-		user, err := o.client.GetUser(ctx, element.ID)
+		user, err := o.client.GetOrganizationUser(ctx, element.ID)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("baton-trayai: GetUser failed: %w", err)
 		}
@@ -78,7 +72,6 @@ func (o *userBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 			return nil, "", nil, fmt.Errorf("baton-trayai: cannot create connector resource: %w", err)
 		}
 
-		o.users[user.ID] = user
 		users = append(users, vUser)
 	}
 
@@ -96,42 +89,6 @@ func (o *userBuilder) Entitlements(_ context.Context, resource *v2.Resource, _ *
 // Grants always returns an empty slice for users since they don't have any entitlements.
 func (o *userBuilder) Grants(ctx context.Context, resource *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
 	return nil, "", nil, nil
-}
-
-func (o *userBuilder) getUsers(ctx context.Context) (map[string]*client.User, error) {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
-	if len(o.users) > 0 {
-		return o.users, nil
-	}
-
-	cursor := ""
-	for {
-		resp, err := o.client.ListUsers(ctx, client.ListParams{
-			Cursor: cursor,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("baton-trayai: getUsers failed: %w", err)
-		}
-
-		for _, element := range resp.Elements {
-			user, err := o.client.GetUser(ctx, element.ID)
-			if err != nil {
-				return nil, fmt.Errorf("baton-trayai: GetUser failed: %w", err)
-			}
-			o.users[user.ID] = user
-		}
-
-		if resp.Page.EndCursor == "" {
-			return o.users, nil
-		}
-
-		if cursor == resp.Page.EndCursor {
-			return nil, fmt.Errorf("baton-trayai: current shouldn't be equal to endCursor")
-		}
-		cursor = resp.Page.EndCursor
-	}
 }
 
 func (o *userBuilder) CreateAccountCapabilityDetails(ctx context.Context) (*v2.CredentialDetailsAccountProvisioning, annotations.Annotations, error) {
@@ -194,6 +151,5 @@ func getCreateUserParams(accountInfo *v2.AccountInfo) (*client.CreateUserParams,
 func newUserBuilder(c *client.Client) *userBuilder {
 	return &userBuilder{
 		client: c,
-		users:  make(map[string]*client.User),
 	}
 }

--- a/pkg/connector/workspaces.go
+++ b/pkg/connector/workspaces.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
@@ -37,8 +38,9 @@ func workspaceResource(ws client.Element) (*v2.Resource, error) {
 }
 
 type workspaceBuilder struct {
-	client   *client.Client
-	uBuilder *userBuilder
+	mu             sync.Mutex
+	client         *client.Client
+	workspaceUsers map[string][]*client.User // map[workspaceID]users
 }
 
 // ResourceType returns the workspace resource type.
@@ -117,16 +119,14 @@ func (w *workspaceBuilder) Grants(ctx context.Context, r *v2.Resource, pToken *p
 		return nil, "", nil, fmt.Errorf("baton-trayai: ListWorkspaceUsers failed: %w", err)
 	}
 
-	grants := make([]*v2.Grant, 0, len(resp.Elements))
-	users, err := w.uBuilder.getUsers(ctx)
-	if err != nil {
-		return nil, "", nil, err
-	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
 
+	grants := make([]*v2.Grant, 0, len(resp.Elements))
 	for _, userID := range resp.Elements {
-		user, ok := users[userID.ID]
-		if !ok {
-			return nil, "", nil, fmt.Errorf("baton-trayai: userID %s not found", userID.ID)
+		user, err := w.client.GetWorkspaceUser(ctx, userID.ID, r.Id.Resource)
+		if err != nil {
+			return nil, "", nil, fmt.Errorf("baton-trayai: GetWorkspaceUser failed: %w", err)
 		}
 
 		userResource, err := resource.NewResourceID(userResourceType, user.ID)
@@ -139,6 +139,10 @@ func (w *workspaceBuilder) Grants(ctx context.Context, r *v2.Resource, pToken *p
 			user.Role.Name,
 			userResource,
 		))
+
+		workspaceUsers := w.workspaceUsers[r.Id.Resource]
+		workspaceUsers = append(workspaceUsers, user)
+		w.workspaceUsers[r.Id.Resource] = workspaceUsers
 	}
 
 	if !resp.Page.HasNextPage {
@@ -147,9 +151,50 @@ func (w *workspaceBuilder) Grants(ctx context.Context, r *v2.Resource, pToken *p
 	return grants, resp.Page.EndCursor, nil, nil
 }
 
-func newWorkspaceBuild(c *client.Client, ubuilder *userBuilder) *workspaceBuilder {
+func (w *workspaceBuilder) getWorkspaceUsers(ctx context.Context, workspaceID string) ([]*client.User, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	workspaceUsers, ok := w.workspaceUsers[workspaceID]
+	if ok {
+		return workspaceUsers, nil
+	}
+
+	cursor := ""
+	for {
+		resp, err := w.client.ListWorkspaceUsers(ctx, client.ListParams{
+			Cursor:      cursor,
+			WorkspaceID: workspaceID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("baton-trayai: ListWorkspaceUsers failed: %w", err)
+		}
+
+		for _, element := range resp.Elements {
+			user, err := w.client.GetWorkspaceUser(ctx, element.ID, workspaceID)
+			if err != nil {
+				return nil, fmt.Errorf("baton-trayai: GetWorkspaceUser failed: %w", err)
+			}
+			workspaceUsers = append(workspaceUsers, user)
+		}
+
+		w.workspaceUsers[workspaceID] = workspaceUsers
+		if resp.Page.EndCursor == "" {
+			break
+		}
+
+		if cursor == resp.Page.EndCursor {
+			return nil, fmt.Errorf("baton-trayai: current cursor shouldn't be equal to endCursor")
+		}
+		cursor = resp.Page.EndCursor
+	}
+
+	w.workspaceUsers[workspaceID] = workspaceUsers
+	return workspaceUsers, nil
+}
+func newWorkspaceBuild(c *client.Client) *workspaceBuilder {
 	return &workspaceBuilder{
-		client:   c,
-		uBuilder: ubuilder,
+		client:         c,
+		workspaceUsers: make(map[string][]*client.User),
 	}
 }


### PR DESCRIPTION
#### Description
- [x] Bug fix

1. One users could have different roles across different workspaces, so we can't use `organization user role` when implementing `func (w *workspaceBuilder) Grants()`
For example, 
user: Ben.Su 
Organization Role: Admin
WorkspaceA Role: Viewer

2. When implementing func (r *roleBuilder) Grant(), we exclude users who are not part of the specified workspaceID.

#### Tests.
<img width="1305" alt="image" src="https://github.com/user-attachments/assets/4762fc55-e010-4c78-97d0-511d2c90a18e" />

#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
