### PR TITLE
Test revoke

### DIFF
--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -362,3 +362,27 @@ func (c *Client) RemoveWorkspaceUser(ctx context.Context, p SetOrDeleteWorkspace
 	defer resp.Body.Close()
 	return nil
 }
+
+func (c *Client) RemoveOrganizationUser(ctx context.Context, p SetOrDeleteWorkspaceRoleParams) error {
+	urlpath, err := url.Parse(basePath + fmt.Sprintf(getUserPath, p.UserID))
+	if err != nil {
+		return err
+	}
+
+	req, err := c.httpClient.NewRequest(ctx,
+		http.MethodDelete,
+		urlpath,
+		uhttp.WithAcceptJSONHeader(),
+		uhttp.WithContentTypeJSONHeader(),
+	)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -186,7 +186,7 @@ func (r *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 	}
 
 	workspaceID := grant.Entitlement.Resource.ParentResourceId.Resource
-	isOrg, err := isOrganization(workspaceID)
+	isOrg, err := r.isOrganization(ctx, workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("baton-trayai: isOrganization failed: %w", err)
 	}
@@ -198,7 +198,7 @@ func (r *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 	return nil, r.client.RemoveOrganizationUser(ctx, params)
 }
 
-func isOrganization(workspaceID string) (bool, error) {
+func (r *roleBuilder) isOrganization(ctx context.Context, workspaceID string) (bool, error) {
 	resp, err := r.client.GetWorkspace(ctx, workspaceID)
 	if err != nil {
 		return false, fmt.Errorf("baton-trayai: GetWorkspace failed: %w", err)

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -165,6 +165,9 @@ func (r *roleBuilder) Grant(ctx context.Context, principal *v2.Resource, entitle
 	}, nil, nil
 }
 
+// Revoke revokes the user from the workspace or organization.
+// 1. if the workspace is an organization, RemoveOrganizationUser is called.
+// 2. if the workspace is not an organization, RemoveWorkspaceUser is called.
 func (r *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.Annotations, error) {
 	if grant == nil || grant.Principal == nil || grant.Principal.Id == nil {
 		return nil, fmt.Errorf("baton-trayai: grant is nil")
@@ -178,10 +181,29 @@ func (r *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 		return nil, fmt.Errorf("baton-trayai: entitlement resource has no parent resource id")
 	}
 
-	return nil, r.client.RemoveWorkspaceUser(ctx, client.SetOrDeleteWorkspaceRoleParams{
-		WorkspaceID: grant.Entitlement.Resource.ParentResourceId.Resource,
-		UserID:      grant.Principal.Id.Resource,
-	})
+	params := client.SetOrDeleteWorkspaceRoleParams{
+		UserID: grant.Principal.Id.Resource,
+	}
+
+	workspaceID := grant.Entitlement.Resource.ParentResourceId.Resource
+	isOrg, err := isOrganization(workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("baton-trayai: isOrganization failed: %w", err)
+	}
+
+	if !isOrg {
+		params.WorkspaceID = workspaceID
+		return nil, r.client.RemoveWorkspaceUser(ctx, params)
+	}
+	return nil, r.client.RemoveOrganizationUser(ctx, params)
+}
+
+func isOrganization(workspaceID string) (bool, error) {
+	resp, err := r.client.GetWorkspace(ctx, workspaceID)
+	if err != nil {
+		return false, fmt.Errorf("baton-trayai: GetWorkspace failed: %w", err)
+	}
+	return resp.Type == "Organization", nil
 }
 
 func newRoleBuilder(c *client.Client, wb *workspaceBuilder) *roleBuilder {


### PR DESCRIPTION
#### Description

Add a RemoveOrganizationUser function to handle removing users from organizations.

In TrayAI, Organization and Workspaces use the same struct but have different names. Therefore, removing users from an organization or a workspace requires calling different APIs.






#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
