### PR TITLE
[BB-451] fix grant in role builder

### DIFF
--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -163,7 +163,13 @@ func (c *Client) ListWorkspaces(ctx context.Context, params ListParams) (*ListRe
 }
 
 func (c *Client) ListWorkspaceRoles(ctx context.Context, params ListParams) (*ListResp, error) {
-	urlpath, err := url.Parse(basePath + fmt.Sprintf(listWorkspaceRolesPath, params.WorkspaceID))
+	// If the workspaceID is not provided, we list the organization roles.
+	trayPath := listOrganizationRolesPath
+	if params.WorkspaceID != "" {
+		trayPath = fmt.Sprintf(listWorkspaceRolesPath, params.WorkspaceID)
+	}
+
+	urlpath, err := url.Parse(basePath + trayPath)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +198,12 @@ func (c *Client) ListWorkspaceRoles(ctx context.Context, params ListParams) (*Li
 }
 
 func (c *Client) ListWorkspaceUsers(ctx context.Context, params ListParams) (*ListResp, error) {
-	urlpath, err := url.Parse(basePath + fmt.Sprintf(listWorkspaceUsersPath, params.WorkspaceID))
+	trayPath := listUsersPath
+	if params.WorkspaceID != "" {
+		trayPath = fmt.Sprintf(listWorkspaceUsersPath, params.WorkspaceID)
+	}
+
+	urlpath, err := url.Parse(basePath + trayPath)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +261,12 @@ func (c *Client) GetOrganizationUser(ctx context.Context, userID string) (*User,
 // GetWorkspaceUser is different from GetOrganizationUser since one user could have different roles in
 // different workspaces.
 func (c *Client) GetWorkspaceUser(ctx context.Context, userID string, workspaceID string) (*User, error) {
-	urlpath, err := url.Parse(basePath + fmt.Sprintf(getWorkspaceUserPath, workspaceID, userID))
+	trayPath := fmt.Sprintf(getUserPath, userID)
+	if workspaceID != "" {
+		trayPath = fmt.Sprintf(getWorkspaceUserPath, workspaceID, userID)
+	}
+
+	urlpath, err := url.Parse(basePath + trayPath)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +325,12 @@ type SetOrDeleteWorkspaceRoleParams struct {
 }
 
 func (c *Client) SetWorkspaceRole(ctx context.Context, p SetOrDeleteWorkspaceRoleParams) error {
-	urlpath, err := url.Parse(basePath + fmt.Sprintf(getWorkspaceUserPath, p.WorkspaceID, p.UserID))
+	// We don't need to pass in the workspaceID if the user is an organization user.
+	trayPath := fmt.Sprintf(getOrganizationRolePath, p.UserID)
+	if p.WorkspaceID != "" {
+		trayPath = fmt.Sprintf(getWorkspaceUserPath, p.WorkspaceID, p.UserID)
+	}
+	urlpath, err := url.Parse(basePath + trayPath)
 	if err != nil {
 		return err
 	}

--- a/pkg/connector/client/path.go
+++ b/pkg/connector/client/path.go
@@ -2,13 +2,15 @@ package client
 
 // For API documentation, see: https://developer.tray.ai/openapi/trayapi/tag/overview/
 const (
-	basePath               = "https://api.tray.io"
-	listUsersPath          = "/core/v1/users"
-	listWorkspacesPath     = "/core/v1/workspaces"
-	listWorkspaceRolesPath = "/core/v1/workspaces/%s/roles"
-	listWorkspaceUsersPath = "/core/v1/workspaces/%s/users"
+	basePath                  = "https://api.tray.io"
+	listUsersPath             = "/core/v1/users"
+	listWorkspacesPath        = "/core/v1/workspaces"
+	listWorkspaceRolesPath    = "/core/v1/workspaces/%s/roles"
+	listOrganizationRolesPath = "/core/v1/roles"
+	listWorkspaceUsersPath    = "/core/v1/workspaces/%s/users"
 
-	getUserPath          = "/core/v1/users/%s"
-	getWorkspacePath     = "/core/v1/workspaces/%s"
-	getWorkspaceUserPath = "/core/v1/workspaces/%s/users/%s"
+	getUserPath             = "/core/v1/users/%s"
+	getOrganizationRolePath = "/core/v1/users/%s/roles"
+	getWorkspacePath        = "/core/v1/workspaces/%s"
+	getWorkspaceUserPath    = "/core/v1/workspaces/%s/users/%s"
 )

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -46,11 +46,20 @@ func (r *roleBuilder) List(ctx context.Context, parentResourceID *v2.ResourceId,
 		return nil, "", nil, nil
 	}
 
-	resp, err := r.client.ListWorkspaceRoles(ctx, client.ListParams{
-		Cursor:      pToken.Token,
-		First:       pToken.Size,
-		WorkspaceID: parentResourceID.Resource,
-	})
+	params := client.ListParams{
+		Cursor: pToken.Token,
+		First:  pToken.Size,
+	}
+	isOrg, err := r.isOrganization(ctx, parentResourceID.Resource)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("baton-trayai: isOrganization failed: %w", err)
+	}
+
+	if !isOrg {
+		params.WorkspaceID = parentResourceID.Resource
+	}
+
+	resp, err := r.client.ListWorkspaceRoles(ctx, params)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("baton-trayai: List workspace roles failed: %w", err)
 	}
@@ -152,11 +161,21 @@ func (r *roleBuilder) Grant(ctx context.Context, principal *v2.Resource, entitle
 		return nil, nil, fmt.Errorf("baton-trayai: invalid resource ID: %s", entitlement.Resource.Id.Resource)
 	}
 
-	err := r.client.SetWorkspaceRole(ctx, client.SetOrDeleteWorkspaceRoleParams{
-		WorkspaceID: entitlement.Resource.ParentResourceId.Resource,
-		UserID:      principal.Id.Resource,
-		RoleID:      resourceIDs[1],
-	})
+	params := client.SetOrDeleteWorkspaceRoleParams{
+		UserID: principal.Id.Resource,
+		RoleID: resourceIDs[1],
+	}
+	workspaceID := entitlement.Resource.ParentResourceId.Resource
+	isOrg, err := r.isOrganization(ctx, workspaceID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-trayai: isOrganization failed: %w", err)
+	}
+
+	if !isOrg {
+		params.WorkspaceID = workspaceID
+	}
+
+	err = r.client.SetWorkspaceRole(ctx, params)
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-trayai: SetWorkspaceRole failed: %w", err)
 	}
@@ -195,6 +214,7 @@ func (r *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 		params.WorkspaceID = workspaceID
 		return nil, r.client.RemoveWorkspaceUser(ctx, params)
 	}
+
 	return nil, r.client.RemoveOrganizationUser(ctx, params)
 }
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -33,6 +33,8 @@ func userResource(
 		[]resource.UserTraitOption{
 			resource.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
 			resource.WithUserProfile(profile),
+			resource.WithEmail(user.Email, true),
+			resource.WithUserLogin(user.Name),
 		},
 		resource.WithParentResourceID(parentResourceID),
 	)

--- a/pkg/connector/workspaces.go
+++ b/pkg/connector/workspaces.go
@@ -110,11 +110,21 @@ func (w *workspaceBuilder) Entitlements(ctx context.Context, resource *v2.Resour
 
 // Grants returns grants for workspace.
 func (w *workspaceBuilder) Grants(ctx context.Context, r *v2.Resource, pToken *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
-	resp, err := w.client.ListWorkspaceUsers(ctx, client.ListParams{
-		Cursor:      pToken.Token,
-		First:       pToken.Size,
-		WorkspaceID: r.Id.Resource,
-	})
+	params := client.ListParams{
+		Cursor: pToken.Token,
+		First:  pToken.Size,
+	}
+
+	isOrg, err := w.isOrganization(ctx, r.Id.Resource)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("baton-trayai: isOrganization failed: %w", err)
+	}
+
+	if !isOrg {
+		params.WorkspaceID = r.Id.Resource
+	}
+
+	resp, err := w.client.ListWorkspaceUsers(ctx, params)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf("baton-trayai: ListWorkspaceUsers failed: %w", err)
 	}
@@ -160,18 +170,26 @@ func (w *workspaceBuilder) getWorkspaceUsers(ctx context.Context, workspaceID st
 		return workspaceUsers, nil
 	}
 
-	cursor := ""
+	params := client.ListParams{
+		Cursor: "",
+	}
+	isOrg, err := w.isOrganization(ctx, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("baton-trayai: isOrganization failed: %w", err)
+	}
+
+	if !isOrg {
+		params.WorkspaceID = workspaceID
+	}
+
 	for {
-		resp, err := w.client.ListWorkspaceUsers(ctx, client.ListParams{
-			Cursor:      cursor,
-			WorkspaceID: workspaceID,
-		})
+		resp, err := w.client.ListWorkspaceUsers(ctx, params)
 		if err != nil {
 			return nil, fmt.Errorf("baton-trayai: ListWorkspaceUsers failed: %w", err)
 		}
 
 		for _, element := range resp.Elements {
-			user, err := w.client.GetWorkspaceUser(ctx, element.ID, workspaceID)
+			user, err := w.client.GetWorkspaceUser(ctx, element.ID, params.WorkspaceID)
 			if err != nil {
 				return nil, fmt.Errorf("baton-trayai: GetWorkspaceUser failed: %w", err)
 			}
@@ -183,10 +201,10 @@ func (w *workspaceBuilder) getWorkspaceUsers(ctx context.Context, workspaceID st
 			break
 		}
 
-		if cursor == resp.Page.EndCursor {
+		if params.Cursor == resp.Page.EndCursor {
 			return nil, fmt.Errorf("baton-trayai: current cursor shouldn't be equal to endCursor")
 		}
-		cursor = resp.Page.EndCursor
+		params.Cursor = resp.Page.EndCursor
 	}
 
 	w.workspaceUsers[workspaceID] = workspaceUsers
@@ -197,4 +215,12 @@ func newWorkspaceBuild(c *client.Client) *workspaceBuilder {
 		client:         c,
 		workspaceUsers: make(map[string][]*client.User),
 	}
+}
+
+func (w *workspaceBuilder) isOrganization(ctx context.Context, workspaceID string) (bool, error) {
+	resp, err := w.client.GetWorkspace(ctx, workspaceID)
+	if err != nil {
+		return false, fmt.Errorf("baton-trayai: GetWorkspace failed: %w", err)
+	}
+	return resp.Type == "Organization", nil
 }


### PR DESCRIPTION
#### Description

- Fix the `Grant` Method in `roleBuilder`
- Organization has a workspaceid. 
-- we have to list roles from `/core/v1/role` instead of `/core/v1/workspaces/{workspaceId}/roles`, since these two api return the same role with different role IDs. Besides, roles from `core/v1/role` are required in entitlement provisioning. 

#### Test.
Revoke.
<img width="1308" alt="image" src="https://github.com/user-attachments/assets/a2b0309c-7130-4f11-97f7-1ac352febdc1" />

Grant
<img width="948" alt="image" src="https://github.com/user-attachments/assets/b005dc1e-bd94-4f61-8b6d-0d2f86165280" />




#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
