### PR TITLE
consolidate baton outputs actions

### DIFF
--- a/.github/workflows/capabilities_and_config.yaml
+++ b/.github/workflows/capabilities_and_config.yaml
@@ -1,4 +1,4 @@
-name: Generate connector capabilities
+name: Generate capabilities and config schema
 
 on:
   push:
@@ -6,7 +6,8 @@ on:
       - main
 
 jobs:
-  calculate-capabilities:
+  generate_outputs:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -18,17 +19,22 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
 
       - name: Build
         run: go build -o connector ./cmd/baton-trayai
 
-      - name: Run and save output
+      - name: Run and save config output
+        run: ./connector config > config_schema.json
+
+      - name: Run and save capabilities output
         run: ./connector --auth-token "test" capabilities > baton_capabilities.json
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v9
         with:
           default_author: github_actions
-          message: 'Updating baton capabilities.'
-          add: 'baton_capabilities.json'
+          message: "Updating baton config schema and capabilities."
+          add: |
+            config_schema.json
+            baton_capabilities.json


### PR DESCRIPTION
#### Description

consolidate baton outputs actions to prevent race conditions on auto merging, and save time with a single job setup
