### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-trayai/main.go
+++ b/cmd/baton-trayai/main.go
@@ -47,7 +47,7 @@ func getConnector(ctx context.Context, tac *cfg.Trayai) (types.ConnectorServer, 
 	}
 
 	authToken := tac.AuthToken
-	cb, err := connector.New(ctx, authToken)
+	cb, err := connector.New(ctx, authToken, tac.BaseUrl)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -5,6 +5,7 @@ import "reflect"
 
 type Trayai struct {
 	AuthToken string `mapstructure:"auth-token"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Trayai) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ var (
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Override the Tray.ai API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ var (
 		"base-url",
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Override the Tray.ai API URL (for testing)"),
+		field.WithHidden(true),
 	)
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,11 +12,16 @@ var (
 		field.WithIsSecret(true),
 		field.WithRequired(true),
 	)
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDisplayName("Base URL"),
+		field.WithDescription("Override the Tray.ai API URL (for testing)"),
+	)
 )
 
 //go:generate go run ./gen
 var Config = field.NewConfiguration(
-	[]field.SchemaField{AuthorizationTokenField},
+	[]field.SchemaField{AuthorizationTokenField, BaseURLField},
 	field.WithConnectorDisplayName("Tray.ai"),
 	field.WithHelpUrl("/docs/baton/trayai"),
 	field.WithIconUrl("/static/app-icons/trayai.svg"),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ var (
 		"base-url",
 		field.WithDisplayName("Base URL"),
 		field.WithDescription("Override the Tray.ai API URL (for testing)"),
+		field.WithDefaultValue("https://api.tray.io"),
 		field.WithHidden(true),
 		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -13,17 +13,24 @@ import (
 // Params is the parameters used to init a tray.io client.
 type Params struct {
 	HttpClient *uhttp.BaseHttpClient
+	BaseURL    string
 }
 
 // Client is used to interact with Tray.io.
 type Client struct {
 	httpClient *uhttp.BaseHttpClient
+	baseURL    string
 }
 
 // NewClient initializes a new tray.ai Client.
 func NewClient(p Params) *Client {
+	baseURL := p.BaseURL
+	if baseURL == "" {
+		baseURL = basePath
+	}
 	return &Client{
 		httpClient: p.HttpClient,
+		baseURL:    baseURL,
 	}
 }
 
@@ -51,7 +58,7 @@ type ListResp struct {
 
 // ListUsers list all the users from tray.ai.
 func (c *Client) ListUsers(ctx context.Context, params ListParams) (*ListResp, error) {
-	urlpath, err := url.Parse(basePath + listUsersPath)
+	urlpath, err := url.Parse(c.baseURL + listUsersPath)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +95,7 @@ type CreateUserParams struct {
 
 // CreateUser is used to create user in tray.ai.
 func (c *Client) CreateUser(ctx context.Context, params *CreateUserParams) (*User, error) {
-	urlpath, err := url.Parse(basePath + listUsersPath)
+	urlpath, err := url.Parse(c.baseURL + listUsersPath)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +123,7 @@ func (c *Client) CreateUser(ctx context.Context, params *CreateUserParams) (*Use
 type AddUserToWorkspaceParams SetOrDeleteWorkspaceRoleParams
 
 func (c *Client) AddUserToWorkspace(ctx context.Context, p AddUserToWorkspaceParams) error {
-	urlpath, err := url.Parse(basePath + fmt.Sprintf(listWorkspaceUsersPath, p.WorkspaceID))
+	urlpath, err := url.Parse(c.baseURL + fmt.Sprintf(listWorkspaceUsersPath, p.WorkspaceID))
 	if err != nil {
 		return err
 	}
@@ -163,7 +170,7 @@ func toQuery(url *url.URL, p ListParams) string {
 }
 
 func (c *Client) ListWorkspaces(ctx context.Context, params ListParams) (*ListResp, error) {
-	urlpath, err := url.Parse(basePath + listWorkspacesPath)
+	urlpath, err := url.Parse(c.baseURL + listWorkspacesPath)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +205,7 @@ func (c *Client) ListWorkspaceRoles(ctx context.Context, params ListParams) (*Li
 		trayPath = fmt.Sprintf(listWorkspaceRolesPath, params.WorkspaceID)
 	}
 
-	urlpath, err := url.Parse(basePath + trayPath)
+	urlpath, err := url.Parse(c.baseURL + trayPath)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +239,7 @@ func (c *Client) ListWorkspaceUsers(ctx context.Context, params ListParams) (*Li
 		trayPath = fmt.Sprintf(listWorkspaceUsersPath, params.WorkspaceID)
 	}
 
-	urlpath, err := url.Parse(basePath + trayPath)
+	urlpath, err := url.Parse(c.baseURL + trayPath)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +268,7 @@ func (c *Client) ListWorkspaceUsers(ctx context.Context, params ListParams) (*Li
 }
 
 func (c *Client) GetOrganizationUser(ctx context.Context, userID string) (*User, error) {
-	urlpath, err := url.Parse(basePath + fmt.Sprintf(getUserPath, userID))
+	urlpath, err := url.Parse(c.baseURL + fmt.Sprintf(getUserPath, userID))
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +302,7 @@ func (c *Client) GetWorkspaceUser(ctx context.Context, userID string, workspaceI
 		trayPath = fmt.Sprintf(getWorkspaceUserPath, workspaceID, userID)
 	}
 
-	urlpath, err := url.Parse(basePath + trayPath)
+	urlpath, err := url.Parse(c.baseURL + trayPath)
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +328,7 @@ func (c *Client) GetWorkspaceUser(ctx context.Context, userID string, workspaceI
 }
 
 func (c *Client) GetWorkspace(ctx context.Context, workspaceID string) (*Workspace, error) {
-	urlpath, err := url.Parse(basePath + fmt.Sprintf(getWorkspacePath, workspaceID))
+	urlpath, err := url.Parse(c.baseURL + fmt.Sprintf(getWorkspacePath, workspaceID))
 	if err != nil {
 		return nil, err
 	}
@@ -359,7 +366,7 @@ func (c *Client) SetWorkspaceRole(ctx context.Context, p SetOrDeleteWorkspaceRol
 	if p.WorkspaceID != "" {
 		trayPath = fmt.Sprintf(getWorkspaceUserPath, p.WorkspaceID, p.UserID)
 	}
-	urlpath, err := url.Parse(basePath + trayPath)
+	urlpath, err := url.Parse(c.baseURL + trayPath)
 	if err != nil {
 		return err
 	}
@@ -390,7 +397,7 @@ func (c *Client) SetWorkspaceRole(ctx context.Context, p SetOrDeleteWorkspaceRol
 }
 
 func (c *Client) RemoveWorkspaceUser(ctx context.Context, p SetOrDeleteWorkspaceRoleParams) error {
-	urlpath, err := url.Parse(basePath + fmt.Sprintf(getWorkspaceUserPath, p.WorkspaceID, p.UserID))
+	urlpath, err := url.Parse(c.baseURL + fmt.Sprintf(getWorkspaceUserPath, p.WorkspaceID, p.UserID))
 	if err != nil {
 		return err
 	}
@@ -414,7 +421,7 @@ func (c *Client) RemoveWorkspaceUser(ctx context.Context, p SetOrDeleteWorkspace
 }
 
 func (c *Client) RemoveOrganizationUser(ctx context.Context, p SetOrDeleteWorkspaceRoleParams) error {
-	urlpath, err := url.Parse(basePath + fmt.Sprintf(getUserPath, p.UserID))
+	urlpath, err := url.Parse(c.baseURL + fmt.Sprintf(getUserPath, p.UserID))
 	if err != nil {
 		return err
 	}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -83,7 +83,7 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, apiKey string) (*Connector, error) {
+func New(ctx context.Context, apiKey string, baseURL string) (*Connector, error) {
 	httpClient, err := uhttp.NewBearerAuth(apiKey).GetClient(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("baton-trayai: cannot init connector: %w", err)
@@ -92,6 +92,7 @@ func New(ctx context.Context, apiKey string) (*Connector, error) {
 	return &Connector{
 		client: trayclient.NewClient(trayclient.Params{
 			HttpClient: uhttp.NewBaseHttpClient(httpClient),
+			BaseURL:    baseURL,
 		}),
 	}, nil
 }


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-trayai/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/client/client.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-trayai --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.