### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -33,11 +33,11 @@ func userResource(
 		userResourceType,
 		user.ID,
 		[]sdkResource.UserTraitOption{
-			sdkResource.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
-			sdkResource.WithUserProfile(profile),
 			sdkResource.WithEmail(user.Email, true),
 			sdkResource.WithUserLogin(user.Name),
 		},
+		sdkResource.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
+		sdkResource.WithResourceProfile(profile),
 		sdkResource.WithParentResourceID(parentResourceID),
 	)
 }

--- a/pkg/connector/workspaces.go
+++ b/pkg/connector/workspaces.go
@@ -21,17 +21,14 @@ func workspaceResource(ws client.Element) (*v2.Resource, error) {
 		ws.Name,
 		workspaceResourceType,
 		ws.ID,
-		[]sdkResource.GroupTraitOption{
-			sdkResource.WithGroupProfile(
-				map[string]interface{}{
-					"workspace_id":               ws.ID,
-					"workspace_name":             ws.Name,
-					"workspace_type":             ws.Type,
-					"workspace_description":      ws.Description,
-					"workspace_monthlyTaskLimit": ws.MonthlyTaskLimit,
-				},
-			),
-		},
+		[]sdkResource.GroupTraitOption{},
+		sdkResource.WithResourceProfile(map[string]interface{}{
+			"workspace_id":               ws.ID,
+			"workspace_name":             ws.Name,
+			"workspace_type":             ws.Type,
+			"workspace_description":      ws.Description,
+			"workspace_monthlyTaskLimit": ws.MonthlyTaskLimit,
+		}),
 		sdkResource.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: roleResourceType.Id},
 		),


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
